### PR TITLE
Allow to install subversions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"require": {
 		"php": "^7.3|^8.0",
-		"sylius/sylius": "1.7|1.8|1.9|1.10"
+		"sylius/sylius": "^1.7|^1.8|^1.9|^1.10"
 	},
 	"require-dev": {
 		"behat/behat": "^3.6.1",


### PR DESCRIPTION
Current composer json does not allow to install for example 1.9.6 version of Sylius, it only allows 1.X.0 versions, where X is (7,8,9,10).