### PR TITLE
Fix sorting init for async bundle load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## V2.1.1
+
+- Fixed sorting initialization when the bundle loads after DOMContentLoaded has already fired. Drag-and-drop now works reliably on large taxons.
+
 ## V2.1.0
 
 - Support for Sylius 2.1 and 2.2

--- a/assets/admin/js/sorting-plugin.js
+++ b/assets/admin/js/sorting-plugin.js
@@ -1,7 +1,7 @@
 import Sortable from 'sortablejs';
 import '../css/sorting-plugin.css';
 
-document.addEventListener('DOMContentLoaded', () => {
+function initSortableContainer() {
   const sortableContainer = document.getElementById('sortableProducts');
 
   if (sortableContainer) {
@@ -15,4 +15,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSortableContainer);
+} else {
+  initSortableContainer();
+}


### PR DESCRIPTION
## Summary

- SortableJS never initializes when the bundle loads after `DOMContentLoaded` has already fired (e.g. on large taxons where the page renders before the chunk finishes downloading/parsing).
- Fixed by checking `document.readyState` and calling the initialiser synchronously if the document is past the loading phase.

## Test plan

- [ ] Open the sorting page for a taxon with many products on Sylius 2.2.
- [ ] Verify drag-and-drop of cards works and that the save-positions flow persists the new order.